### PR TITLE
Re-factored code that handles dropped flight tabs.

### DIFF
--- a/track.css
+++ b/track.css
@@ -217,7 +217,8 @@ fieldset {
 
 .flightStatusTable ul {
     list-style-type: none;
-    padding-left: 0px;
+    padding: 0.4em 0.4em 0.4em 0em;
+    margin: 0.5em;
 }
 
 .departuresList li, .arrivalsList li {
@@ -227,11 +228,11 @@ fieldset {
     margin: 1em;
 }
 
-.deps {
+.departuresList li {
     background-color: var(--departureGreen);
 }
 
-.arrs {
+.arrivalsList li {
     background-color: var(--arrivalBlue);
 }
 

--- a/track.js
+++ b/track.js
@@ -16,8 +16,11 @@ $(function(){
     let flightNumberValid = "";
     let aircraftTypeValid = "";
     let statusValid = "";
-    // let originalColor = true;
-    
+
+    /* Constants */
+    const depsGreen = "rgb(0, 119, 0)";
+    const arrsBlue = "rgb(0, 90, 200)";
+    const emergencyColor = "rgb(187, 0, 0)";
 
     /* Re-set input fields on window refresh */
     window.onload = function(){
@@ -39,11 +42,24 @@ $(function(){
     $("#departures, #arrivals").sortable({
         connectWith: ".dragAndDropList",
         receive: function(event, ui){
-            if($(ui.item).hasClass("deps")){
-                $(ui.item).switchClass("deps", "arrs");
+            if(ui.item.hasClass("deps")){
+                ui.item.removeClass("deps").addClass("arrs");
+
+                if(ui.item.css("background-color") == emergencyColor){
+                    $(".arrivalsList ul").prepend(ui.item);
+                    return;
+                }
+
+                ui.item.css("background-color", arrsBlue);
             }
             else{
-                $(ui.item).switchClass("arrs", "deps");
+                ui.item.removeClass("arrs").addClass("deps");
+
+                if(ui.item.css("background-color") == emergencyColor){
+                    return;
+                }
+
+                ui.item.css("background-color", depsGreen);
             }
         }
     }).disableSelection();
@@ -86,9 +102,6 @@ $(function(){
     $(document).on("click", ".emergencyButton", function(){
         let statusClass = $(this).parent().attr("class");
         let originalColor = $(this).parent().css("background-color");
-        let depsGreen = "rgb(0, 119, 0)";
-        let arrsBlue = "rgb(0, 90, 200)";
-        let emergencyColor = "rgb(187, 0, 0);"
 
         switch(statusClass){
             case "deps":
@@ -210,9 +223,6 @@ $(function(){
 
     /* Generates a flight tab based on the user inputs and puts it in the appropriate column */
     function generateFlightTabs(vaCode, flightNumber, aircraftType) {
-        let departingFlight = "";
-        let arrivingFlight = "";
-
         if($(statusButton).html() == "Dep"){
             $(".departuresList ul").append("<li class='deps'>" + vaCode + " | " + flightNumber + " | " +
                 aircraftType + " | <button class='emergencyButton'>E</button> | <button class='deleteTabButton'>Del(X)</button></li>");


### PR DESCRIPTION
In the receive property that handles the behaviour of flight tabs that are dropped into either the arrivals or departures unordered lists, the behaviour of flight tabs was not occurring as expected.

So I re-factored the code that begins on line 44 of the sortable function. The "receive" event will now check the "incoming" flight tab - if it's a departures tab in green, then its class name is now changed to "arrs" and is checked for background color. If the background color is red (the flight has already declared an emergency), the tab will remain red and will automatically be positioned at the top of the list, giving that flight priority. Any other flight tabs will get adjusted below it automatically. If the "incoming" flight tab is not an emergency flight (just a regular flight), then its color will get changed to blue (for arrivals).

The same procedure is applicable for tabs dropped from the arrivals column into the departures column.